### PR TITLE
Trim excess newlines inside paragraphs

### DIFF
--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -56,6 +56,7 @@
               (if a (org-gfm-export-to-markdown t s v)
                 (org-open-file (org-gfm-export-to-markdown nil s v)))))))
   :translate-alist '((inner-template . org-gfm-inner-template)
+		     (paragraph . org-gfm-paragraph)
                      (strike-through . org-gfm-strike-through)
                      (src-block . org-gfm-src-block)
                      (table-cell . org-gfm-table-cell)
@@ -65,6 +66,22 @@
 
 
 ;;; Transcode Functions
+
+;;;; Paragraph
+
+(defun org-gfm-paragraph (paragraph contents _info)
+  "Transcode PARAGRAPH element into Github Flavoured Markdown format.
+CONTENTS is the paragraph contents.  INFO is a plist used as a
+communication channel."
+  (let ((contents
+         (concat (replace-regexp-in-string "\\\n" "" contents nil t)
+                 "\n")))
+    (let ((first-object (car (org-element-contents paragraph))))
+      ;; If paragraph starts with a #, protect it.
+      (if (and (stringp first-object) (string-match "\\`#" first-object))
+          (replace-regexp-in-string "\\`#" "\\#" contents nil t)
+        contents))))
+
 
 ;;;; Src Block
 


### PR DESCRIPTION
Github Flavored Markdown recognizes new line character `\n` is end of a paragraph, thus a markdown snippet like this:

```markdown
This is a small exporter based on the Markdown exporter
already existing in Org mode. It should support the features listed
here.

The exporter has made it's way into to the contrib section of Org,
and can be found here.
```

Would be rendered on Github as below:

----
This is a small exporter based on the Markdown exporter
already existing in Org mode. It should support the features listed
here.

The exporter has made it's way into to the contrib section of Org,
and can be found here.

----

To keep markdown outputs generated by `ox-gfm` consistent with Github Flavored Markdown (and thus make them look prettier on Github), I trimmed excess new line character in a paragraph except the last one, thus the markdown output of the same Org-Mode snippet would look like:

```markdown
This is a small exporter based on the Markdown exporter already existing in Org mode. It should support the features listed here.

The exporter has made it's way into to the contrib section of Org,and can be found here.
```

And looks perfect on Github:

----
This is a small exporter based on the Markdown exporter already existing in Org mode. It should support the features listed here.

The exporter has made it's way into to the contrib section of Org,and can be found here.

----

Thanks.
cc @larstvei 