### PR TITLE
Fix missing whitespaces in exported paragraphs.

### DIFF
--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -74,7 +74,7 @@
 CONTENTS is the paragraph contents.  INFO is a plist used as a
 communication channel."
   (let ((contents
-         (concat (replace-regexp-in-string "\\\n" "" contents nil t)
+         (concat (mapconcat 'identity (split-string contents) " ")
                  "\n")))
     (let ((first-object (car (org-element-contents paragraph))))
       ;; If paragraph starts with a #, protect it.


### PR DESCRIPTION
In [my last patch](https://github.com/larstvei/ox-gfm/pull/7), I used `replace-regexp-in-string` to trim newline character `\n` at the end of each line. Unfortunately, it concatenates two (or more) lines directly without inserting whitespaces in-between. This patch should fix the aforementioned bug.

For this modification, a lisp function `split-string` from `subr.el` is used. `split-string` makes no assumption about whitespaces at the *start* or the *end* of input string, so it is safer, as quoted from its documentation:

>If you want to trim whitespace from the substrings, the reliably correct
>way is using TRIM.  Making SEPARATORS match that whitespace gives incorrect
>results when there is whitespace at the start or end of STRING.  If you
>see such calls to ‘split-string’, please fix them.

Also, I have made a living example in my fork of [orgmk](https://github.com/scottoasis/orgmk/blob/master/README.md). 

Thanks.