### PR TITLE
When preserve-breaks is set on, skip trimming newline in paragraph

### DIFF
--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -69,10 +69,13 @@
 
 ;;;; Paragraph
 
-(defun org-gfm-paragraph (paragraph contents _info)
+(defun org-gfm-paragraph (paragraph contents info)
   "Transcode PARAGRAPH element into Github Flavoured Markdown format.
 CONTENTS is the paragraph contents.  INFO is a plist used as a
 communication channel."
+  (unless (plist-get info :preserve-breaks)
+    (setq contents (concat (mapconcat 'identity (split-string contents) " ")
+                 "\n")))
   (let ((first-object (car (org-element-contents paragraph))))
     ;; If paragraph starts with a #, protect it.
     (if (and (stringp first-object) (string-match "\\`#" first-object))

--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -73,14 +73,11 @@
   "Transcode PARAGRAPH element into Github Flavoured Markdown format.
 CONTENTS is the paragraph contents.  INFO is a plist used as a
 communication channel."
-  (let ((contents
-         (concat (mapconcat 'identity (split-string contents) " ")
-                 "\n")))
-    (let ((first-object (car (org-element-contents paragraph))))
-      ;; If paragraph starts with a #, protect it.
-      (if (and (stringp first-object) (string-match "\\`#" first-object))
-          (replace-regexp-in-string "\\`#" "\\#" contents nil t)
-        contents))))
+  (let ((first-object (car (org-element-contents paragraph))))
+    ;; If paragraph starts with a #, protect it.
+    (if (and (stringp first-object) (string-match "\\`#" first-object))
+	(replace-regexp-in-string "\\`#" "\\#" contents nil t)
+      contents)))
 
 
 ;;;; Src Block


### PR DESCRIPTION
In the current version, the following option doesn't work well.  

    #+OPTIONS: \n:t

I've added the sentence that check whether the options is set on.  
If the option is valid, trimming newline in paragraph will be skipped, 
otherwise the operation proceeds in the same manner as before.  
