### PR TITLE
Render footnote section as HTML

### DIFF
--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -254,7 +254,7 @@ holding export options."
          (headlines (and depth (org-export-collect-headlines info depth)))
          (toc-string (or (mapconcat 'org-gfm-format-toc headlines "\n") ""))
          (toc-tail (if headlines "\n\n" "")))
-    (concat toc-string toc-tail contents "\n" (org-html-footnote-section info))))
+    (org-trim (concat toc-string toc-tail contents "\n" (org-html-footnote-section info)))))
         
 
 

--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -254,7 +254,9 @@ holding export options."
          (headlines (and depth (org-export-collect-headlines info depth)))
          (toc-string (or (mapconcat 'org-gfm-format-toc headlines "\n") ""))
          (toc-tail (if headlines "\n\n" "")))
-    (concat toc-string toc-tail contents)))
+    (concat toc-string toc-tail contents "\n" (org-html-footnote-section info))))
+        
+
 
 
 

--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -242,6 +242,36 @@ plist used as a communication channel."
     (concat indent "- [" title "]" "(#" anchor ")")))
 
 
+;;;; Footnote section
+
+(defun org-gfm-footnote-section (info)
+  "Format the footnote section.
+INFO is a plist used as a communication channel."
+  (let* ((fn-alist (org-export-collect-footnote-definitions info))
+         (fn-alist
+          (loop for (n type raw) in fn-alist collect
+                (cons n (org-trim (org-export-data raw info))))))
+    (when fn-alist
+      (format
+       "## %s\n%s"
+       "Footnotes"
+       (format
+        "\n%s\n"
+        (mapconcat
+         (lambda (fn)
+           (let ((n (car fn)) (def (cdr fn)))
+             (format
+              "%s %s\n"
+              (format
+               (plist-get info :html-footnote-format)
+               (org-html--anchor
+                (format "fn.%d" n)
+                n
+                (format " class=\"footnum\" href=\"#fnr.%d\"" n)
+                info))
+              def)))
+         fn-alist
+         "\n"))))))
 
 
 ;;;; Template
@@ -254,7 +284,7 @@ holding export options."
          (headlines (and depth (org-export-collect-headlines info depth)))
          (toc-string (or (mapconcat 'org-gfm-format-toc headlines "\n") ""))
          (toc-tail (if headlines "\n\n" "")))
-    (org-trim (concat toc-string toc-tail contents "\n" (org-html-footnote-section info)))))
+    (org-trim (concat toc-string toc-tail contents "\n" (org-gfm-footnote-section info)))))
         
 
 


### PR DESCRIPTION
Appends a footnote section, transcoded to HTML, to the GFM output. 
Fixes #11 

/cc @jonmagic

Org source
------------

```org
* Heading
test ~one~ two this[fn:1] is some text.
More text have another footnote[fn:2].

* Footnotes

[fn:1] This is a footnote.

[fn:2] This is another footnote.

```

Output before
-----------------------

```
  - [Heading](#orgheadline1)

  # Heading<a id="orgheadline1"></a>

  test `one` two this<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> is some text.
  More text have another footnote<sup><a id="fnr.2" class="footref" href="#fn.2">2</a></sup>.
```


Output after
----------------------

```
  - [Heading](#orgheadline1)

  # Heading<a id="orgheadline1"></a>

  test `one` two this<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> is some text.
  More text have another footnote<sup><a id="fnr.2" class="footref" href="#fn.2">2</a></sup>.

  <div id="footnotes">
  <h2 class="footnotes">Footnotes: </h2>
  <div id="text-footnotes">

  <div class="footdef"><sup><a id="fn.1" class="footnum" href="#fnr.1">1</a></sup> <div class="footpara">This is a footnote.</div></div>

  <div class="footdef"><sup><a id="fn.2" class="footnum" href="#fnr.2">2</a></sup> <div class="footpara">This is another footnote.</div></div>

  </div>
  </div>
```
