### PR TITLE
Add support for publishing via ox-gfm

### DIFF
--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -28,8 +28,7 @@
 ;;; Code:
 
 (require 'ox-md)
-
-
+(require 'ox-publish)
 
 ;;; User-Configurable Variables
 
@@ -354,6 +353,15 @@ Return output file's name."
   (interactive)
   (let ((outfile (org-export-output-file-name ".md" subtreep)))
     (org-export-to-file 'gfm outfile async subtreep visible-only)))
+
+;;;###autoload
+(defun org-gfm-publish-to-gfm (plist filename pub-dir)
+  "Publish an org file to Markdown.
+FILENAME is the filename of the Org file to be published.  PLIST
+is the property list for the given project.  PUB-DIR is the
+publishing directory.
+Return output file name."
+  (org-publish-org-to 'gfm filename ".md" plist pub-dir))
 
 (provide 'ox-gfm)
 


### PR DESCRIPTION
This provides support for using ox-gfm to [publish](http://orgmode.org/manual/Publishing.html) org mode projects.

I took this directly from `ox-md` and it seems to work fine. I haven't tested it extensively though.

Let me know if it needs any work, or if it dosen't work for you!