### PR TITLE
Use prefixed version of cl-loop

### DIFF
--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -248,7 +248,7 @@ plist used as a communication channel."
 INFO is a plist used as a communication channel."
   (let* ((fn-alist (org-export-collect-footnote-definitions info))
          (fn-alist
-          (loop for (n type raw) in fn-alist collect
+          (cl-loop for (n type raw) in fn-alist collect
                 (cons n (org-trim (org-export-data raw info))))))
     (when fn-alist
       (format


### PR DESCRIPTION
I ran into some issues with the un-prefixed `loop` combined with the `for` keyword. I think the issue is that newer versions of Emacs don't alias `loop` to `cl-loop` by default? I had to explicitly require `cl` to make it work.