### PR TITLE
org-gfm-toc: Wrap the TOC in a div for styling

### DIFF
--- a/ox-gfm.el
+++ b/ox-gfm.el
@@ -266,8 +266,14 @@ holding export options."
                                       (org-gfm-format-toc headline info))
                                     headlines "\n")
                          ""))
-         (toc-tail (if headlines "\n\n" "")))
-    (org-trim (concat toc-string toc-tail contents "\n" (org-gfm-footnote-section info)))))
+         (toc-head (if headlines "<div class=\"orgtoc\">\n" ""))
+         (toc-tail (if headlines "\n</div>\n\n" "")))
+    (org-trim (concat toc-head
+                      toc-string
+                      toc-tail
+                      contents
+                      "\n"
+                      (org-gfm-footnote-section info)))))
 
 
 ;;; Interactive function


### PR DESCRIPTION
It's possible that this change is not useful to anyone but me. 

But since it's quite common to style the Table of Contents specially, I thought about contributing it back to the project.

It's a simple change that wraps the generated TOC in a div, which the user can then style according to their requirements.